### PR TITLE
Fix for message.data check on Mac

### DIFF
--- a/server.py
+++ b/server.py
@@ -43,10 +43,10 @@ class PebbleWebSocket(WebSocket):
 
 		# Mac
 		if isMac():
-			if message.data == 'down':
+			if message.data == bytes('down', 'utf-8'):
 				cmd = "osascript -e 'tell application \"System Events\" to keystroke (ASCII character 29)'"
 				os.system(cmd)
-			elif message.data == 'up':
+			elif message.data == bytes('up', 'utf-8'):
 				cmd = "osascript -e 'tell application \"System Events\" to keystroke (ASCII character 28)'"
 				os.system(cmd)
 


### PR DESCRIPTION
Another fix for Mac, please :-) The message data wasn't passing the comparison check with either 'down' or 'up', apparently due to the data being binary rather than a string. An explicit bytes conversion for the string we're checking for did the trick...
