### PR TITLE
Adding netifaces to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyUserInput==0.1.9
 ws4py==0.3.2
+netifaces==0.10.5


### PR DESCRIPTION
`netifaces` package is required.

Also, `python-xlib` is needed, but only on Linux, so I'm not including it here.